### PR TITLE
Make the isSpreadOperator string check more explicit

### DIFF
--- a/lib/rules/sort-object-keys.js
+++ b/lib/rules/sort-object-keys.js
@@ -61,7 +61,7 @@ function getSortingPropertyName(property) {
  * @returns {boolean} is the string a spread operator
  */
 function isSpreadOperator(string) {
-  return string ? string.slice(0, 3) === '...' : false;
+  return typeof string === 'string' ? string.slice(0, 3) === '...' : false;
 }
 
 /**


### PR DESCRIPTION
Prevents breakages when truthy but not a string